### PR TITLE
Table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 *.pyc
 dist/
-*.egg_info/
+*.egg-info/

--- a/setup.py
+++ b/setup.py
@@ -10,11 +10,23 @@
 
 import os
 import sys
+import platform
 
 from setuptools import setup, find_packages
 
 sys.path.append(".")
 from omeroserver.version import omeroserver_version as osv  # noqa
+
+names = ["debian-9", "debian-stretch", "ubuntu-16", "xenial"]
+
+
+def tables_package():
+    name = platform.platform()
+    package_version = "tables"
+    for n in names:
+        if name.find(n) >= 0:
+            package_version = "tables<3.6"
+    return package_version
 
 
 def read(fname):
@@ -53,7 +65,7 @@ setup(name="omero-server",
           'omero-py',
           # minimum requirements for `omero admin start`
           'omero-certificates',
-          'tables',
+          tables_package(),
       ],
       include_package_data=True,
       tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -53,12 +53,12 @@ setup(name="omero-server",
           'omero-py',
           # minimum requirements for `omero admin start`
           'omero-certificates',
-          'tables',
       ],
       include_package_data=True,
       tests_require=['pytest'],
       extras_require={
         "debian9": ["tables<3.6"],
         "ubuntu1604": ["tables<3.6"],
+        "default": ["tables"],
       }
       )

--- a/setup.py
+++ b/setup.py
@@ -69,4 +69,8 @@ setup(name="omero-server",
       ],
       include_package_data=True,
       tests_require=['pytest'],
+      extras_require={
+        'debian9': ['tables<3.6'],
+        'ubuntu1604': ['tables<3.6'],
+      }
       )

--- a/setup.py
+++ b/setup.py
@@ -10,23 +10,11 @@
 
 import os
 import sys
-import platform
 
 from setuptools import setup, find_packages
 
 sys.path.append(".")
 from omeroserver.version import omeroserver_version as osv  # noqa
-
-names = ["debian-9", "debian-stretch", "ubuntu-16.04", "xenial"]
-
-
-def tables_package():
-    name = platform.platform().lower()
-    package_version = "tables"
-    for n in names:
-        if name.find(n) >= 0:
-            package_version = "tables<3.6"
-    return package_version
 
 
 def read(fname):
@@ -65,7 +53,7 @@ setup(name="omero-server",
           'omero-py',
           # minimum requirements for `omero admin start`
           'omero-certificates',
-          tables_package(),
+          'tables',
       ],
       include_package_data=True,
       tests_require=['pytest'],

--- a/setup.py
+++ b/setup.py
@@ -17,11 +17,11 @@ from setuptools import setup, find_packages
 sys.path.append(".")
 from omeroserver.version import omeroserver_version as osv  # noqa
 
-names = ["debian-9", "debian-stretch", "ubuntu-16", "xenial"]
+names = ["debian-9", "debian-stretch", "ubuntu-16.04", "xenial"]
 
 
 def tables_package():
-    name = platform.platform()
+    name = platform.platform().lower()
     package_version = "tables"
     for n in names:
         if name.find(n) >= 0:

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ setup(name="omero-server",
       include_package_data=True,
       tests_require=['pytest'],
       extras_require={
-        'debian9': ['tables<3.6'],
-        'ubuntu1604': ['tables<3.6'],
+        "debian9": ["tables<3.6", "mock<2.0"],
+        "ubuntu1604": ["tables<3.6"],
       }
       )

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(name="omero-server",
       include_package_data=True,
       tests_require=['pytest'],
       extras_require={
-        "debian9": ["tables<3.6", "mock<2.0"],
+        "debian9": ["tables<3.6"],
         "ubuntu1604": ["tables<3.6"],
       }
       )

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ deps =
     tables
     pytest
     PyYAML
-    py36: tables
     pytest-sugar
     pytest-xdist
     restructuredtext-lint


### PR DESCRIPTION
This PR caps the version of tables depending on the OS
None of the "supported markers" (see https://www.python.org/dev/peps/pep-0508/#environment-markers) could be used to return the info needed.

A cleaner way might be possible

Tested this PR via 
https://travis-ci.org/github/jburel/omero-install

