### PR TITLE
Add omero-metadata as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,6 +51,8 @@ setup(
     install_requires=[
         # requires Ice (use wheel for faster installs)
         "omero-py",
+        # dependency of the Populate Metadata script
+        "omero-metadata",
         # minimum requirements for `omero admin start`
         "omero-certificates",
     ],


### PR DESCRIPTION
See comment https://github.com/ome/omero-guide-upload/pull/13#discussion_r561775698 for background.

Fully open to discussion. The Populate Metadata script is very popular, and smoothening of the path to install it would be desirable. Not sure this is the best way, but let us make a suggestion.


cc @manics @joshmoore @sbesson 