### PR TITLE
Adjust build

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/psf/black
-    rev: 22.10.0
+    rev: 23.3.0
     hooks:
       - id: black
         args: [--target-version=py36]
   - repo: https://github.com/PyCQA/flake8
-    rev: 5.0.4
+    rev: 6.0.0
     hooks:
       - id: flake8
         args: [

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,7 @@ passenv =
     ICE_CONFIG
     PIP_CACHE_DIR
 commands =
-    pre-commit run --all-files
+    py38,py39: pre-commit run --all-files
     rst-lint README.rst
     python setup.py sdist install --record files.txt
     pytest {posargs:-n4 -rf test -s}

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,6 @@ deps =
     pytest-sugar
     pytest-xdist
     restructuredtext-lint
-    https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp36-cp36m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.6"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp37-cp37m-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.7"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp38-cp38-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.8"
     https://github.com/ome/zeroc-ice-py-github-ci/releases/download/0.1.0/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl; platform_system=="Linux" and python_version=="3.9"

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,4 @@
 [tox]
-envlist = py36
 # https://tox.readthedocs.io/en/latest/config.html#conf-requires
 # Ensure pip is new so we can install manylinux wheel
 requires = pip >= 19.0.0


### PR DESCRIPTION
This PR removes ref to py3.6
It also fixes issue in build https://github.com/ome/omero-cli-server/pull/26 due to Flake8 6.0.0 which now requires Python 3.8+