### PR TITLE
cap pytables to 3.9

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
         "omero-py",
         # minimum requirements for `omero admin start`
         "omero-certificates",
-        "tables",
+        "tables<3.9",
     ],
     include_package_data=True,
     tests_require=["pytest"],


### PR DESCRIPTION
Our CI failed due to the release of pytables 3.9 
See https://github.com/PyTables/PyTables/issues/1062 
this PR caps the version of ``tables``.
This is used installation instructions 
See for example https://omero.readthedocs.io/en/stable/sysadmins/unix/server-centos7-ice36.html